### PR TITLE
Improve app layout in grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Mac App Directory
+
+This repository lists several macOS apps with minimal configuration files and a simple webpage to browse and download them. Each app lives in its own folder inside `apps/` containing:
+
+- `config.json` – the app name and download link
+- `icon.svg` – a placeholder icon due to limited network access
+
+Open `index.html` in a browser to see the searchable list in a grid layout. Click any app card to visit the download page. Icons can be replaced with official artwork once available.

--- a/apps/1password/config.json
+++ b/apps/1password/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "1Password",
+  "link": "https://1password.com/downloads/mac"
+}

--- a/apps/1password/icon.svg
+++ b/apps/1password/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">1</text>
+</svg>

--- a/apps/alcove/config.json
+++ b/apps/alcove/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Alcove",
+  "link": "https://tryalcove.com/download"
+}

--- a/apps/alcove/icon.svg
+++ b/apps/alcove/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">A</text>
+</svg>

--- a/apps/amie/config.json
+++ b/apps/amie/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Amie",
+  "link": "https://amie.so/download"
+}

--- a/apps/amie/icon.svg
+++ b/apps/amie/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">A</text>
+</svg>

--- a/apps/arc_browser/config.json
+++ b/apps/arc_browser/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Arc Browser",
+  "link": "https://arc.net/download"
+}

--- a/apps/arc_browser/icon.svg
+++ b/apps/arc_browser/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">A</text>
+</svg>

--- a/apps/chatgpt/config.json
+++ b/apps/chatgpt/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "ChatGPT",
+  "link": "https://openai.com/chatgpt/download"
+}

--- a/apps/chatgpt/icon.svg
+++ b/apps/chatgpt/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">C</text>
+</svg>

--- a/apps/cleanshot_x/config.json
+++ b/apps/cleanshot_x/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "CleanShot X",
+  "link": "https://cleanshot.com/download"
+}

--- a/apps/cleanshot_x/icon.svg
+++ b/apps/cleanshot_x/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">C</text>
+</svg>

--- a/apps/cursor/config.json
+++ b/apps/cursor/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Cursor",
+  "link": "https://cursor.sh/downloads"
+}

--- a/apps/cursor/icon.svg
+++ b/apps/cursor/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">C</text>
+</svg>

--- a/apps/daylight_desktop/config.json
+++ b/apps/daylight_desktop/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Daylight Desktop",
+  "link": "https://apps.apple.com/app/daylight-desktop/id6503941498"
+}

--- a/apps/daylight_desktop/icon.svg
+++ b/apps/daylight_desktop/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">D</text>
+</svg>

--- a/apps/developer_(apple)/config.json
+++ b/apps/developer_(apple)/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Developer (Apple)",
+  "link": "https://apps.apple.com/app/apple-developer/id640199958"
+}

--- a/apps/developer_(apple)/icon.svg
+++ b/apps/developer_(apple)/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">D</text>
+</svg>

--- a/apps/discord/config.json
+++ b/apps/discord/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Discord",
+  "link": "https://discord.com/download"
+}

--- a/apps/discord/icon.svg
+++ b/apps/discord/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">D</text>
+</svg>

--- a/apps/focusrite_control_2/config.json
+++ b/apps/focusrite_control_2/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Focusrite Control 2",
+  "link": "https://focusrite.com/software/focusrite-control-2"
+}

--- a/apps/focusrite_control_2/icon.svg
+++ b/apps/focusrite_control_2/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">F</text>
+</svg>

--- a/apps/ghostty/config.json
+++ b/apps/ghostty/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ghostty",
+  "link": "https://ghostty.org/download"
+}

--- a/apps/ghostty/icon.svg
+++ b/apps/ghostty/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">G</text>
+</svg>

--- a/apps/github_desktop/config.json
+++ b/apps/github_desktop/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "GitHub Desktop",
+  "link": "https://desktop.github.com"
+}

--- a/apps/github_desktop/icon.svg
+++ b/apps/github_desktop/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">G</text>
+</svg>

--- a/apps/homerow/config.json
+++ b/apps/homerow/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Homerow",
+  "link": "https://www.homerow.app"
+}

--- a/apps/homerow/icon.svg
+++ b/apps/homerow/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">H</text>
+</svg>

--- a/apps/klack/config.json
+++ b/apps/klack/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Klack",
+  "link": "https://apps.apple.com/app/klack/id6446206067"
+}

--- a/apps/klack/icon.svg
+++ b/apps/klack/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">K</text>
+</svg>

--- a/apps/linear/config.json
+++ b/apps/linear/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Linear",
+  "link": "https://linear.app/download"
+}

--- a/apps/linear/icon.svg
+++ b/apps/linear/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">L</text>
+</svg>

--- a/apps/raycast/config.json
+++ b/apps/raycast/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Raycast",
+  "link": "https://www.raycast.com/download"
+}

--- a/apps/raycast/icon.svg
+++ b/apps/raycast/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">R</text>
+</svg>

--- a/apps/rectangle/config.json
+++ b/apps/rectangle/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Rectangle",
+  "link": "https://rectangleapp.com/download"
+}

--- a/apps/rectangle/icon.svg
+++ b/apps/rectangle/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">R</text>
+</svg>

--- a/apps/sf_symbols/config.json
+++ b/apps/sf_symbols/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "SF Symbols",
+  "link": "https://developer.apple.com/sf-symbols"
+}

--- a/apps/sf_symbols/icon.svg
+++ b/apps/sf_symbols/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">S</text>
+</svg>

--- a/apps/slack/config.json
+++ b/apps/slack/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Slack",
+  "link": "https://slack.com/downloads/mac"
+}

--- a/apps/slack/icon.svg
+++ b/apps/slack/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">S</text>
+</svg>

--- a/apps/superhuman/config.json
+++ b/apps/superhuman/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Superhuman",
+  "link": "https://superhuman.com/download"
+}

--- a/apps/superhuman/icon.svg
+++ b/apps/superhuman/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">S</text>
+</svg>

--- a/apps/superwhisper/config.json
+++ b/apps/superwhisper/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "superwhisper",
+  "link": "https://superwhisper.com"
+}

--- a/apps/superwhisper/icon.svg
+++ b/apps/superwhisper/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">S</text>
+</svg>

--- a/apps/telegram/config.json
+++ b/apps/telegram/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Telegram",
+  "link": "https://macos.telegram.org"
+}

--- a/apps/telegram/icon.svg
+++ b/apps/telegram/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">T</text>
+</svg>

--- a/apps/testflight/config.json
+++ b/apps/testflight/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "TestFlight",
+  "link": "https://apps.apple.com/app/testflight/id899247664"
+}

--- a/apps/testflight/icon.svg
+++ b/apps/testflight/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">T</text>
+</svg>

--- a/apps/xcode/config.json
+++ b/apps/xcode/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Xcode",
+  "link": "https://apps.apple.com/app/xcode/id497799835"
+}

--- a/apps/xcode/icon.svg
+++ b/apps/xcode/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">X</text>
+</svg>

--- a/apps/yubico_authenticator/config.json
+++ b/apps/yubico_authenticator/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Yubico Authenticator",
+  "link": "https://www.yubico.com/products/yubico-authenticator/"
+}

--- a/apps/yubico_authenticator/icon.svg
+++ b/apps/yubico_authenticator/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">Y</text>
+</svg>

--- a/apps/zoom/config.json
+++ b/apps/zoom/config.json
@@ -1,0 +1,4 @@
+{
+  "name": "Zoom",
+  "link": "https://zoom.us/download?os=mac"
+}

--- a/apps/zoom/icon.svg
+++ b/apps/zoom/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="20" ry="20" fill="#007AFF" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="60" font-family="Helvetica, Arial, sans-serif" fill="white">Z</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mac App Downloads</title>
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    background-color: #f5f5f7;
+    color: #1d1d1f;
+    margin: 0;
+    padding: 20px;
+  }
+  h1 {
+    font-weight: 600;
+  }
+  .search {
+    margin-bottom: 20px;
+  }
+  .app-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 20px;
+  }
+  .app-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: #fff;
+    padding: 20px;
+    border-radius: 12px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  }
+  .app-item img {
+    width: 60px;
+    height: 60px;
+    margin-bottom: 10px;
+    border-radius: 12px;
+  }
+  .app-name {
+    font-size: 16px;
+    font-weight: 500;
+    margin-top: 5px;
+  }
+  a {
+    color: #0066cc;
+    text-decoration: none;
+  }
+</style>
+</head>
+<body>
+<h1>Mac App Downloads</h1>
+<input class="search" type="text" id="search" placeholder="Search apps" aria-label="Search apps">
+<ul class="app-list" id="appList"></ul>
+<script>
+  const appFolders = [
+    "1password",
+    "alcove",
+    "amie",
+    "arc_browser",
+    "chatgpt",
+    "cleanshot_x",
+    "cursor",
+    "daylight_desktop",
+    "developer_(apple)",
+    "discord",
+    "focusrite_control_2",
+    "ghostty",
+    "github_desktop",
+    "homerow",
+    "klack",
+    "linear",
+    "raycast",
+    "rectangle",
+    "sf_symbols",
+    "slack",
+    "superhuman",
+    "superwhisper",
+    "telegram",
+    "testflight",
+    "xcode",
+    "yubico_authenticator",
+    "zoom",
+  ];
+
+  function loadApps() {
+    const promises = appFolders.map(folder => fetch(`apps/${folder}/config.json`).then(r => r.json().then(data => ({...data, folder}))));
+    Promise.all(promises).then(apps => {
+      apps.sort((a, b) => a.name.localeCompare(b.name));
+      const list = document.getElementById('appList');
+      list.innerHTML = '';
+      const query = document.getElementById('search').value.toLowerCase();
+      apps.filter(app => app.name.toLowerCase().includes(query)).forEach(app => {
+        const li = document.createElement('li');
+        li.className = 'app-item';
+        const img = document.createElement('img');
+        img.src = `apps/${app.folder}/icon.svg`;
+        img.alt = `${app.name} icon`;
+        const link = document.createElement('a');
+        link.href = app.link;
+        link.textContent = app.name;
+        link.target = "_blank";
+        link.className = 'app-name';
+        li.appendChild(img);
+        li.appendChild(link);
+        list.appendChild(li);
+      });
+    });
+  }
+
+  document.getElementById('search').addEventListener('input', loadApps);
+  loadApps();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- style app list as a responsive grid
- open links in a new tab
- document placeholder icons

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68407f861b44832c836208982f76fe32